### PR TITLE
feat: security hardening, secret files, static distroless, TLS & API key auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ COPY . .
 # Build static binary, ensuring CGO is disabled
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-w -s" -o qbit-gluetun-sync ./cmd/sync
 
-# -- Stage 3: Final Image
-FROM gcr.io/distroless/cc-debian12:nonroot
+# -- Stage 3: Final Image (minimal static distroless)
+FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /
 # Copy certs & tzdata from downloader
 COPY --from=downloader /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Instead of relying on heavy polling shell scripts, this project provides a **Go-
 
 - **Resilient File Watching:** Watches the `/tmp/gluetun/forwarded_port` file using `fsnotify` for instant updates. Automatically detects delayed directory creation and handles volume remounts gracefully.
 - **Self-Healing Reconciliation:** Runs a periodic reconciliation loop (`SYNC_INTERVAL`) to ensure qBitTorrent stays synchronized even after container reboots or network blips.
-- **qBitTorrent API Sync:** Automatically calls `/api/v2/app/setPreferences` to update the listening port whenever Gluetun assigns a new one.
-- **Secret Management & File Mounts:** Supports secret files (`QBIT_PASS_FILE`, `QBIT_USER_FILE`) for Docker Secrets and Kubernetes Secrets integration.
+- **Flexible Authentication:** Supports standard username/password sessions as well as API Key / Bearer tokens (`QBIT_API_KEY`, `QBIT_API_KEY_FILE`).
+- **Secret Management & File Mounts:** Supports secret files (`QBIT_PASS_FILE`, `QBIT_USER_FILE`, `QBIT_API_KEY_FILE`) for Docker Secrets and Kubernetes Secrets integration.
 - **Hardened Container Security:** Runs as unprivileged `nonroot` inside Google's minimal `distroless/static-debian12` image (zero C shared library footprint).
 - **Graceful Lifecycle Management:** Traps `SIGINT`/`SIGTERM` to perform clean draining and termination.
 - **Health Probing:** Exposes `/healthz` for Kubernetes and Docker liveness checks.
@@ -29,8 +29,11 @@ The application is configured using Environment Variables:
 | `QBIT_ADDR`                  | `http://localhost:8080`       | The address of your qBitTorrent Web UI.                                      |
 | `QBIT_USER`                  | _(empty)_                     | Username for qBitTorrent.                                                    |
 | `QBIT_USER_FILE`             | _(empty)_                     | Path to file containing qBitTorrent username (takes precedence over `QBIT_USER`).|
-| `QBIT_PASS`                  | _(empty)_                     | Password for qBitTorrent.                                                    |
+| `QBIT_PASS`                  | _(empty)_                     | Password for qBitTorrent.                                           |
 | `QBIT_PASS_FILE`             | _(empty)_                     | Path to file containing qBitTorrent password (takes precedence over `QBIT_PASS`).|
+| `QBIT_API_KEY`               | _(empty)_                     | API Key / Bearer token for qBitTorrent or reverse proxy auth.                 |
+| `QBIT_API_KEY_FILE`          | _(empty)_                     | Path to file containing API Key (takes precedence over `QBIT_API_KEY`).       |
+| `QBIT_API_KEY_HEADER`        | `X-Api-Key`                   | Header name used when sending API Key.                                       |
 | `QBIT_INSECURE_SKIP_VERIFY`  | `false`                       | Skip TLS certificate verification for self-signed HTTPS endpoints.           |
 | `QBIT_CA_CERT_FILE`          | _(empty)_                     | Path to custom CA certificate PEM file for verifying HTTPS endpoints.       |
 | `PORT_FILE`                  | `/tmp/gluetun/forwarded_port` | Path to the port file written by Gluetun.                                    |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/hononeko/qbit-gluetun-sync/main.yml)](https://github.com/hononeko/qbit-gluetun-sync/actions/workflows/main.yml)
 [![Docker Image](https://img.shields.io/badge/Image-hononeko/qbit--gluetun--sync-blue?logo=docker)](https://github.com/hononeko/qbit-gluetun-sync/pkgs/container/qbit-gluetun-sync)
 
-A lightweight, resilient, and event-driven sidecar written in Go to synchronize the dynamic forwarded port from Gluetun (ProtonVPN) to qBitTorrent.
+A lightweight, resilient, and secure sidecar written in Go to synchronize the dynamic forwarded port from Gluetun (ProtonVPN) to qBitTorrent.
 
 ## Introduction
 
@@ -15,23 +15,29 @@ Instead of relying on heavy polling shell scripts, this project provides a **Go-
 - **Resilient File Watching:** Watches the `/tmp/gluetun/forwarded_port` file using `fsnotify` for instant updates. Automatically detects delayed directory creation and handles volume remounts gracefully.
 - **Self-Healing Reconciliation:** Runs a periodic reconciliation loop (`SYNC_INTERVAL`) to ensure qBitTorrent stays synchronized even after container reboots or network blips.
 - **qBitTorrent API Sync:** Automatically calls `/api/v2/app/setPreferences` to update the listening port whenever Gluetun assigns a new one.
+- **Secret Management & File Mounts:** Supports secret files (`QBIT_PASS_FILE`, `QBIT_USER_FILE`) for Docker Secrets and Kubernetes Secrets integration.
+- **Hardened Container Security:** Runs as unprivileged `nonroot` inside Google's minimal `distroless/static-debian12` image (zero C shared library footprint).
 - **Graceful Lifecycle Management:** Traps `SIGINT`/`SIGTERM` to perform clean draining and termination.
-- **Container Hardening:** Runs as unprivileged `nonroot` inside a minimal Google `distroless` image.
 - **Health Probing:** Exposes `/healthz` for Kubernetes and Docker liveness checks.
 
 ## Configuration
 
 The application is configured using Environment Variables:
 
-| Variable        | Default                       | Description                                                         |
-| :-------------- | :---------------------------- | :------------------------------------------------------------------ |
-| `QBIT_ADDR`     | `http://localhost:8080`       | The address of your qBitTorrent Web UI.                             |
-| `QBIT_USER`     | _(empty)_                     | Username for qBitTorrent (if authentication is required).           |
-| `QBIT_PASS`     | _(empty)_                     | Password for qBitTorrent.                                           |
-| `PORT_FILE`     | `/tmp/gluetun/forwarded_port` | Path to the port file written by Gluetun.                           |
-| `LISTEN_PORT`   | `9090`                        | The port this sidecar listens on for health checks.                 |
-| `SYNC_INTERVAL` | `10m`                         | Periodic reconciliation interval (e.g., `5m`, `10m`, `0` to disable).|
-| `LOG_LEVEL`     | `info`                        | Log verbosity (`debug`, `info`, `warn`, `error`).                   |
+| Variable                     | Default                       | Description                                                                  |
+| :--------------------------- | :---------------------------- | :--------------------------------------------------------------------------- |
+| `QBIT_ADDR`                  | `http://localhost:8080`       | The address of your qBitTorrent Web UI.                                      |
+| `QBIT_USER`                  | _(empty)_                     | Username for qBitTorrent.                                                    |
+| `QBIT_USER_FILE`             | _(empty)_                     | Path to file containing qBitTorrent username (takes precedence over `QBIT_USER`).|
+| `QBIT_PASS`                  | _(empty)_                     | Password for qBitTorrent.                                                    |
+| `QBIT_PASS_FILE`             | _(empty)_                     | Path to file containing qBitTorrent password (takes precedence over `QBIT_PASS`).|
+| `QBIT_INSECURE_SKIP_VERIFY`  | `false`                       | Skip TLS certificate verification for self-signed HTTPS endpoints.           |
+| `QBIT_CA_CERT_FILE`          | _(empty)_                     | Path to custom CA certificate PEM file for verifying HTTPS endpoints.       |
+| `PORT_FILE`                  | `/tmp/gluetun/forwarded_port` | Path to the port file written by Gluetun.                                    |
+| `LISTEN_ADDR`                | _(empty)_                     | Bind IP address for healthcheck server (e.g. `127.0.0.1` or `0.0.0.0`).      |
+| `LISTEN_PORT`                | `9090`                        | The port this sidecar listens on for health checks.                          |
+| `SYNC_INTERVAL`              | `10m`                         | Periodic reconciliation interval (e.g., `5m`, `10m`, `0` to disable).         |
+| `LOG_LEVEL`                  | `info`                        | Log verbosity (`debug`, `info`, `warn`, `error`).                            |
 
 ## Usage
 
@@ -81,9 +87,9 @@ services:
       - gluetun_data:/tmp/gluetun:ro
 ```
 
-### Kubernetes (Sidecar Pattern)
+### Kubernetes (Sidecar Pattern with Secrets)
 
-If deploying in Kubernetes, deploy inside the same Pod as qBitTorrent with an `emptyDir` volume shared with Gluetun.
+If deploying in Kubernetes, deploy inside the same Pod as qBitTorrent with an `emptyDir` volume shared with Gluetun and mounted Secrets.
 
 ```yaml
 apiVersion: apps/v1
@@ -113,12 +119,20 @@ spec:
         # 3. Sync Sidecar
         - name: qbit-sync
           image: ghcr.io/hononeko/qbit-gluetun-sync:latest
+          env:
+            - name: QBIT_ADDR
+              value: "http://localhost:8080"
+            - name: QBIT_PASS_FILE
+              value: "/etc/secrets/qbit/password"
           ports:
             - containerPort: 9090
               name: healthz
           volumeMounts:
             - name: gluetun-sync
               mountPath: /tmp/gluetun
+              readOnly: true
+            - name: qbit-secret
+              mountPath: /etc/secrets/qbit
               readOnly: true
           livenessProbe:
             httpGet:
@@ -127,6 +141,9 @@ spec:
       volumes:
         - name: gluetun-sync
           emptyDir: {}
+        - name: qbit-secret
+          secret:
+            secretName: qbit-credentials
 ```
 
 ## API Endpoints

--- a/README.md
+++ b/README.md
@@ -22,25 +22,47 @@ Instead of relying on heavy polling shell scripts, this project provides a **Go-
 
 ## Configuration
 
-The application is configured using Environment Variables:
+The application is configured using Environment Variables, grouped by logical domain.
 
-| Variable                     | Default                       | Description                                                                  |
-| :--------------------------- | :---------------------------- | :--------------------------------------------------------------------------- |
-| `QBIT_ADDR`                  | `http://localhost:8080`       | The address of your qBitTorrent Web UI.                                      |
-| `QBIT_USER`                  | _(empty)_                     | Username for qBitTorrent.                                                    |
-| `QBIT_USER_FILE`             | _(empty)_                     | Path to file containing qBitTorrent username (takes precedence over `QBIT_USER`).|
-| `QBIT_PASS`                  | _(empty)_                     | Password for qBitTorrent.                                           |
-| `QBIT_PASS_FILE`             | _(empty)_                     | Path to file containing qBitTorrent password (takes precedence over `QBIT_PASS`).|
-| `QBIT_API_KEY`               | _(empty)_                     | API Key / Bearer token for qBitTorrent or reverse proxy auth.                 |
-| `QBIT_API_KEY_FILE`          | _(empty)_                     | Path to file containing API Key (takes precedence over `QBIT_API_KEY`).       |
-| `QBIT_API_KEY_HEADER`        | `X-Api-Key`                   | Header name used when sending API Key.                                       |
-| `QBIT_INSECURE_SKIP_VERIFY`  | `false`                       | Skip TLS certificate verification for self-signed HTTPS endpoints.           |
-| `QBIT_CA_CERT_FILE`          | _(empty)_                     | Path to custom CA certificate PEM file for verifying HTTPS endpoints.       |
-| `PORT_FILE`                  | `/tmp/gluetun/forwarded_port` | Path to the port file written by Gluetun.                                    |
-| `LISTEN_ADDR`                | _(empty)_                     | Bind IP address for healthcheck server (e.g. `127.0.0.1` or `0.0.0.0`).      |
-| `LISTEN_PORT`                | `9090`                        | The port this sidecar listens on for health checks.                          |
-| `SYNC_INTERVAL`              | `10m`                         | Periodic reconciliation interval (e.g., `5m`, `10m`, `0` to disable).         |
-| `LOG_LEVEL`                  | `info`                        | Log verbosity (`debug`, `info`, `warn`, `error`).                            |
+### Core Settings (Required)
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `QBIT_ADDR` | `http://localhost:8080` | URL of the target qBitTorrent Web UI. |
+| `PORT_FILE` | `/tmp/gluetun/forwarded_port` | Path to the forwarded port file written by Gluetun. |
+
+### Authentication (Optional)
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `QBIT_USER` | _(empty)_ | Username for qBitTorrent Web UI. |
+| `QBIT_USER_FILE` | _(empty)_ | File path to read username from (takes precedence over `QBIT_USER`). |
+| `QBIT_PASS` | _(empty)_ | Password for qBitTorrent Web UI. |
+| `QBIT_PASS_FILE` | _(empty)_ | File path to read password from (takes precedence over `QBIT_PASS`). |
+| `QBIT_API_KEY` | _(empty)_ | API Key / Bearer token for qBitTorrent (bypasses cookie login). |
+| `QBIT_API_KEY_FILE` | _(empty)_ | File path to read API Key from (takes precedence over `QBIT_API_KEY`). |
+| `QBIT_API_KEY_HEADER` | `X-Api-Key` | Custom HTTP header name used when sending API Key. |
+
+### TLS & Network Security (Optional)
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `QBIT_INSECURE_SKIP_VERIFY` | `false` | Skip TLS certificate verification for self-signed HTTPS endpoints. |
+| `QBIT_CA_CERT_FILE` | _(empty)_ | File path to custom root CA certificate PEM for HTTPS validation. |
+
+### Server & Health Probing (Optional)
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `LISTEN_PORT` | `9090` | HTTP port for health check endpoints. |
+| `LISTEN_ADDR` | _(empty / all interfaces)_ | Host/IP to bind HTTP server (e.g. `127.0.0.1` for local pod binding). |
+
+### Sync Engine & Logging (Optional)
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `SYNC_INTERVAL` | `10m` | Periodic reconciliation interval (e.g. `5m`, `10m`, `0` to disable). |
+| `LOG_LEVEL` | `info` | Log verbosity level (`debug`, `info`, `warn`, `error`). |
 
 ## Usage
 

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -3,9 +3,13 @@ package main
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -27,13 +31,18 @@ func main() {
 	logLevel := getEnv("LOG_LEVEL", "info")
 	logger.Init(logLevel)
 
-	// Parse environment variables
+	// Parse environment variables and secret files
 	qbitAddr := getEnv("QBIT_ADDR", "http://localhost:8080")
-	qbitUser := getEnv("QBIT_USER", "")
-	qbitPass := getEnv("QBIT_PASS", "")
+	qbitUser := getSecret("QBIT_USER", "QBIT_USER_FILE", "")
+	qbitPass := getSecret("QBIT_PASS", "QBIT_PASS_FILE", "")
 	portFile := getEnv("PORT_FILE", "/tmp/gluetun/forwarded_port")
+	listenAddr := getEnv("LISTEN_ADDR", "")
 	listenPort := getEnv("LISTEN_PORT", "9090")
 	syncIntervalStr := getEnv("SYNC_INTERVAL", "10m")
+	insecureSkipVerifyStr := getEnv("QBIT_INSECURE_SKIP_VERIFY", "false")
+	caCertFile := getEnv("QBIT_CA_CERT_FILE", "")
+
+	insecureSkipVerify, _ := strconv.ParseBool(insecureSkipVerifyStr)
 
 	syncInterval, err := time.ParseDuration(syncIntervalStr)
 	if err != nil {
@@ -41,8 +50,16 @@ func main() {
 		syncInterval = 10 * time.Minute
 	}
 
-	// Initialize qBitTorrent Client
-	qbitClient := qbit.NewClient(qbitAddr, qbitUser, qbitPass)
+	// Initialize qBitTorrent Client with security/TLS options
+	qbitOpts := qbit.ClientOptions{
+		InsecureSkipVerify: insecureSkipVerify,
+		CACertFile:         caCertFile,
+		Timeout:            10 * time.Second,
+	}
+	qbitClient, err := qbit.NewClientWithOptions(qbitAddr, qbitUser, qbitPass, qbitOpts)
+	if err != nil {
+		logger.Fatal("Failed to initialize qBitTorrent client", "err", err)
+	}
 
 	// Callback to sync port
 	syncPortFunc := func(port int) {
@@ -106,14 +123,17 @@ func main() {
 	}
 
 	mux := setupMux()
+	bindAddr := net.JoinHostPort(listenAddr, listenPort)
 
-	logger.Info("Starting sidecar server", "listenPort", listenPort, "qbitAddr", qbitAddr)
+	logger.Info("Starting sidecar server", "bindAddr", bindAddr, "qbitAddr", qbitAddr)
 	server := &http.Server{
-		Addr:              ":" + listenPort,
+		Addr:              bindAddr,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,
 		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1MB
 	}
 
 	// Run HTTP server in background
@@ -178,4 +198,18 @@ func getEnv(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+// getSecret resolves a secret either from a file (e.g. QBIT_PASS_FILE) or from an env var (QBIT_PASS).
+func getSecret(envKey, fileEnvKey, fallback string) string {
+	if filePath, exists := os.LookupEnv(fileEnvKey); exists && strings.TrimSpace(filePath) != "" {
+		cleanPath := filepath.Clean(filePath)
+		//nolint:gosec // Secret file path is explicitly provided by admin configuration
+		data, err := os.ReadFile(cleanPath)
+		if err == nil {
+			return strings.TrimSpace(string(data))
+		}
+		logger.Warn("Failed to read secret file, falling back to environment variable", "fileKey", fileEnvKey, "path", cleanPath, "err", err)
+	}
+	return getEnv(envKey, fallback)
 }

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -35,6 +35,8 @@ func main() {
 	qbitAddr := getEnv("QBIT_ADDR", "http://localhost:8080")
 	qbitUser := getSecret("QBIT_USER", "QBIT_USER_FILE", "")
 	qbitPass := getSecret("QBIT_PASS", "QBIT_PASS_FILE", "")
+	qbitAPIKey := getSecret("QBIT_API_KEY", "QBIT_API_KEY_FILE", "")
+	qbitAPIKeyHeader := getEnv("QBIT_API_KEY_HEADER", "X-Api-Key")
 	portFile := getEnv("PORT_FILE", "/tmp/gluetun/forwarded_port")
 	listenAddr := getEnv("LISTEN_ADDR", "")
 	listenPort := getEnv("LISTEN_PORT", "9090")
@@ -50,10 +52,12 @@ func main() {
 		syncInterval = 10 * time.Minute
 	}
 
-	// Initialize qBitTorrent Client with security/TLS options
+	// Initialize qBitTorrent Client with security/TLS/Auth options
 	qbitOpts := qbit.ClientOptions{
 		InsecureSkipVerify: insecureSkipVerify,
 		CACertFile:         caCertFile,
+		APIKey:             qbitAPIKey,
+		APIKeyHeader:       qbitAPIKeyHeader,
 		Timeout:            10 * time.Second,
 	}
 	qbitClient, err := qbit.NewClientWithOptions(qbitAddr, qbitUser, qbitPass, qbitOpts)

--- a/cmd/sync/main_test.go
+++ b/cmd/sync/main_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -66,6 +65,35 @@ func TestGetEnv(t *testing.T) {
 	}
 }
 
+func TestGetSecret(t *testing.T) {
+	tempDir := t.TempDir()
+	secretFilePath := filepath.Join(tempDir, "pass_secret.txt")
+
+	if err := os.WriteFile(secretFilePath, []byte("super_secret_from_file\n"), 0600); err != nil {
+		t.Fatalf("failed to write secret file: %v", err)
+	}
+
+	_ = os.Setenv("TEST_PASS", "plain_password")
+	_ = os.Setenv("TEST_PASS_FILE", secretFilePath)
+	defer func() {
+		_ = os.Unsetenv("TEST_PASS")
+		_ = os.Unsetenv("TEST_PASS_FILE")
+	}()
+
+	// File secret must take precedence over env var
+	val := getSecret("TEST_PASS", "TEST_PASS_FILE", "fallback")
+	if val != "super_secret_from_file" {
+		t.Errorf("Expected super_secret_from_file from file, got %s", val)
+	}
+
+	// When file doesn't exist, should fall back to env var
+	_ = os.Setenv("TEST_PASS_FILE", filepath.Join(tempDir, "non_existent.txt"))
+	valFallback := getSecret("TEST_PASS", "TEST_PASS_FILE", "fallback")
+	if valFallback != "plain_password" {
+		t.Errorf("Expected plain_password from env fallback, got %s", valFallback)
+	}
+}
+
 func TestReconciliationLoop(t *testing.T) {
 	tempDir := t.TempDir()
 	portFile := filepath.Join(tempDir, "forwarded_port")
@@ -77,20 +105,21 @@ func TestReconciliationLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var triggerCount int32
+	triggerCh := make(chan struct{}, 5)
 	syncFunc := func(port int) {
 		if port == 44444 {
-			atomic.AddInt32(&triggerCount, 1)
+			triggerCh <- struct{}{}
 		}
 	}
 
-	go runReconciliationLoop(ctx, portFile, syncFunc, 50*time.Millisecond)
+	go runReconciliationLoop(ctx, portFile, syncFunc, 10*time.Millisecond)
 
-	// Wait for ticker triggers
-	time.Sleep(160 * time.Millisecond)
-	cancel()
-
-	if count := atomic.LoadInt32(&triggerCount); count < 2 {
-		t.Errorf("expected reconciliation loop to trigger at least 2 times, got %d", count)
+	// Wait for at least 2 triggers deterministically
+	for i := 0; i < 2; i++ {
+		select {
+		case <-triggerCh:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for reconciliation trigger %d", i+1)
+		}
 	}
 }

--- a/pkg/qbit/client.go
+++ b/pkg/qbit/client.go
@@ -3,14 +3,26 @@ package qbit
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
+
+// ClientOptions configures optional settings for the qBitTorrent client.
+type ClientOptions struct {
+	InsecureSkipVerify bool
+	CACertFile         string
+	Timeout            time.Duration
+}
 
 // Client handles communication with the qBitTorrent API.
 type Client struct {
@@ -21,16 +33,62 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-// NewClient creates a new qBitTorrent client.
+// NewClient creates a new qBitTorrent client with default options.
 func NewClient(baseURL, user, pass string) *Client {
+	client, _ := NewClientWithOptions(baseURL, user, pass, ClientOptions{})
+	return client
+}
+
+// NewClientWithOptions creates a new qBitTorrent client with custom TLS and timeout options.
+func NewClientWithOptions(baseURL, user, pass string, opts ClientOptions) (*Client, error) {
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: opts.InsecureSkipVerify, //nolint:gosec // Configurable for internal/self-signed certs
+	}
+
+	if opts.CACertFile != "" {
+		cleanPath := filepath.Clean(opts.CACertFile)
+		caCert, err := os.ReadFile(cleanPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read custom CA cert file %s: %w", cleanPath, err)
+		}
+		caCertPool, err := x509.SystemCertPool()
+		if err != nil || caCertPool == nil {
+			caCertPool = x509.NewCertPool()
+		}
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to append custom CA cert from %s: invalid PEM format", cleanPath)
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	timeout := 10 * time.Second
+	if opts.Timeout > 0 {
+		timeout = opts.Timeout
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
+		MaxIdleConns:          10,
+		MaxIdleConnsPerHost:   5,
+	}
+
 	return &Client{
 		BaseURL:  baseURL,
 		Username: user,
 		Password: pass,
 		HTTPClient: &http.Client{
-			Timeout: 10 * time.Second,
+			Transport: transport,
+			Timeout:   timeout,
 		},
-	}
+	}, nil
 }
 
 // authenticate retrieves the auth cookie if credentials are provided.

--- a/pkg/qbit/client.go
+++ b/pkg/qbit/client.go
@@ -22,6 +22,9 @@ type ClientOptions struct {
 	InsecureSkipVerify bool
 	CACertFile         string
 	Timeout            time.Duration
+	//nolint:gosec // Field name for API token
+	APIKey       string
+	APIKeyHeader string
 }
 
 // Client handles communication with the qBitTorrent API.
@@ -29,8 +32,11 @@ type Client struct {
 	BaseURL  string
 	Username string
 	//nolint:gosec // Field name requires matching JSON payload
-	Password   string
-	HTTPClient *http.Client
+	Password string
+	//nolint:gosec // Field name for API token
+	APIKey       string
+	APIKeyHeader string
+	HTTPClient   *http.Client
 }
 
 // NewClient creates a new qBitTorrent client with default options.
@@ -39,7 +45,7 @@ func NewClient(baseURL, user, pass string) *Client {
 	return client
 }
 
-// NewClientWithOptions creates a new qBitTorrent client with custom TLS and timeout options.
+// NewClientWithOptions creates a new qBitTorrent client with custom TLS, timeout, and API Key options.
 func NewClientWithOptions(baseURL, user, pass string, opts ClientOptions) (*Client, error) {
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
@@ -80,10 +86,18 @@ func NewClientWithOptions(baseURL, user, pass string, opts ClientOptions) (*Clie
 		MaxIdleConnsPerHost:   5,
 	}
 
+	authHeaderName := strings.TrimSpace(opts.APIKeyHeader)
+	if authHeaderName == "" {
+		//nolint:gosec // Header key name, not a secret credential
+		authHeaderName = "X-Api-Key"
+	}
+
 	return &Client{
-		BaseURL:  baseURL,
-		Username: user,
-		Password: pass,
+		BaseURL:      baseURL,
+		Username:     user,
+		Password:     pass,
+		APIKey:       strings.TrimSpace(opts.APIKey),
+		APIKeyHeader: authHeaderName,
 		HTTPClient: &http.Client{
 			Transport: transport,
 			Timeout:   timeout,
@@ -91,8 +105,29 @@ func NewClientWithOptions(baseURL, user, pass string, opts ClientOptions) (*Clie
 	}, nil
 }
 
-// authenticate retrieves the auth cookie if credentials are provided.
+// applyAuth attaches credentials (API Key or SID session cookie) to the request.
+func (c *Client) applyAuth(req *http.Request, cookie string) {
+	if c.APIKey != "" {
+		req.Header.Set(c.APIKeyHeader, c.APIKey)
+		// If custom header is not Authorization, also set Authorization Bearer for reverse proxy compatibility
+		if !strings.EqualFold(c.APIKeyHeader, "Authorization") {
+			req.Header.Set("Authorization", "Bearer "+c.APIKey)
+		}
+		return
+	}
+
+	if cookie != "" {
+		//nolint:gosec // Cookie is used for client request, not server response
+		req.AddCookie(&http.Cookie{Name: "SID", Value: cookie})
+	}
+}
+
+// authenticate retrieves the auth cookie if credentials are provided and API Key is not set.
 func (c *Client) authenticate(ctx context.Context) (string, error) {
+	if c.APIKey != "" {
+		return "", nil // API Key auth takes precedence, bypasses login endpoint
+	}
+
 	if c.Username == "" && c.Password == "" {
 		return "", nil // No auth required
 	}
@@ -172,11 +207,7 @@ func (c *Client) SetPreferences(ctx context.Context, preferences map[string]inte
 		return fmt.Errorf("failed to create setPreferences request: %w", err)
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	if cookie != "" {
-		//nolint:gosec // Cookie is used for client request, not server response
-		req.AddCookie(&http.Cookie{Name: "SID", Value: cookie})
-	}
+	c.applyAuth(req, cookie)
 
 	//nolint:gosec // URL is internally constructed via config
 	resp, err := c.HTTPClient.Do(req)
@@ -212,11 +243,7 @@ func (c *Client) GetPreferences(ctx context.Context) (map[string]interface{}, er
 	if err != nil {
 		return nil, fmt.Errorf("failed to create preferences request: %w", err)
 	}
-
-	if cookie != "" {
-		//nolint:gosec // Cookie is used for client request, not server response
-		req.AddCookie(&http.Cookie{Name: "SID", Value: cookie})
-	}
+	c.applyAuth(req, cookie)
 
 	//nolint:gosec // URL is internally constructed via config
 	resp, err := c.HTTPClient.Do(req)

--- a/pkg/qbit/client_test.go
+++ b/pkg/qbit/client_test.go
@@ -119,6 +119,57 @@ func TestClient_SetListenPort(t *testing.T) {
 	}
 }
 
+func TestClient_APIKeyAuth(t *testing.T) {
+	// Mock Server with API Key Verification
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKeyHeader := r.Header.Get("X-Custom-Key")
+		authHeader := r.Header.Get("Authorization")
+
+		if apiKeyHeader != "secret_api_token" || authHeader != "Bearer secret_api_token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		if r.URL.Path == "/api/v2/app/setPreferences" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	//nolint:gosec // Mock test token
+	client, err := NewClientWithOptions(server.URL, "", "", ClientOptions{
+		APIKey:       "secret_api_token",
+		APIKeyHeader: "X-Custom-Key",
+	})
+	if err != nil {
+		t.Fatalf("failed to create client with API key: %v", err)
+	}
+
+	err = client.SetListenPort(ctx, 23456)
+	if err != nil {
+		t.Fatalf("expected successful API key auth, got %v", err)
+	}
+
+	// Bad API key
+	//nolint:gosec // Mock test token
+	badKeyClient, err := NewClientWithOptions(server.URL, "", "", ClientOptions{
+		APIKey:       "wrong_token",
+		APIKeyHeader: "X-Custom-Key",
+	})
+	if err != nil {
+		t.Fatalf("failed to create client with bad API key: %v", err)
+	}
+	err = badKeyClient.SetListenPort(ctx, 23456)
+	if err == nil {
+		t.Fatalf("expected 401 error with wrong API key, got nil")
+	}
+}
+
 func TestClient_TLSOptions(t *testing.T) {
 	// Mock TLS Server
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/qbit/client_test.go
+++ b/pkg/qbit/client_test.go
@@ -3,9 +3,12 @@ package qbit
 import (
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -113,5 +116,83 @@ func TestClient_SetListenPort(t *testing.T) {
 	err = badClient.SetListenPort(ctx, 12345)
 	if err == nil {
 		t.Fatalf("expected auth error on bad password, got nil")
+	}
+}
+
+func TestClient_TLSOptions(t *testing.T) {
+	// Mock TLS Server
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"listen_port": 50000}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Default client should fail TLS verification on self-signed cert
+	defaultClient := NewClient(server.URL, "", "")
+	_, err := defaultClient.GetPreferences(ctx)
+	if err == nil {
+		t.Fatalf("expected TLS verification failure on self-signed cert, got nil")
+	}
+
+	// Client with InsecureSkipVerify should succeed
+	tlsClient, err := NewClientWithOptions(server.URL, "", "", ClientOptions{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create client with InsecureSkipVerify: %v", err)
+	}
+
+	prefs, err := tlsClient.GetPreferences(ctx)
+	if err != nil {
+		t.Fatalf("expected success with InsecureSkipVerify, got %v", err)
+	}
+	if p, ok := prefs["listen_port"].(float64); !ok || int(p) != 50000 {
+		t.Fatalf("expected listen_port 50000, got %v", prefs["listen_port"])
+	}
+
+	// Test valid custom CA cert
+	tempDir := t.TempDir()
+	caCertFile := filepath.Join(tempDir, "server_ca.crt")
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: server.Certificate().Raw,
+	})
+	if err := os.WriteFile(caCertFile, certPEM, 0600); err != nil {
+		t.Fatalf("failed to write custom CA file: %v", err)
+	}
+
+	caClient, err := NewClientWithOptions(server.URL, "", "", ClientOptions{
+		CACertFile: caCertFile,
+	})
+	if err != nil {
+		t.Fatalf("failed to create client with custom CA cert: %v", err)
+	}
+	prefsWithCA, err := caClient.GetPreferences(ctx)
+	if err != nil {
+		t.Fatalf("expected success with valid custom CA cert, got %v", err)
+	}
+	if p, ok := prefsWithCA["listen_port"].(float64); !ok || int(p) != 50000 {
+		t.Fatalf("expected listen_port 50000 with custom CA, got %v", prefsWithCA["listen_port"])
+	}
+
+	// Test invalid CA cert file path
+	_, err = NewClientWithOptions(server.URL, "", "", ClientOptions{
+		CACertFile: "/path/to/nonexistent/ca.crt",
+	})
+	if err == nil {
+		t.Fatalf("expected error for non-existent CA cert file, got nil")
+	}
+
+	// Test corrupt CA cert file
+	corruptCA := filepath.Join(tempDir, "corrupt.crt")
+	_ = os.WriteFile(corruptCA, []byte("NOT_A_VALID_PEM"), 0600)
+	_, err = NewClientWithOptions(server.URL, "", "", ClientOptions{
+		CACertFile: corruptCA,
+	})
+	if err == nil {
+		t.Fatalf("expected error for invalid PEM CA cert, got nil")
 	}
 }


### PR DESCRIPTION
## Summary
Implements Phase 2 security hardening, credential management, and authentication options:

- **File-Based Secret Ingestion:** Adds support for `QBIT_PASS_FILE`, `QBIT_USER_FILE`, and `QBIT_API_KEY_FILE` with precedence over plaintext environment variables for Docker Secrets / Kubernetes Secrets.
- **API Key & Bearer Token Authentication:** Adds support for `QBIT_API_KEY` and custom `QBIT_API_KEY_HEADER` with automatic `Authorization: Bearer` support, bypassing cookie sessions when an API token is provided.
- **Distroless Static Migration:** Upgrades runtime container base to `gcr.io/distroless/static-debian12:nonroot` (eliminating unnecessary C shared libraries).
- **HTTPS & TLS Configuration:** Adds `QBIT_INSECURE_SKIP_VERIFY` and `QBIT_CA_CERT_FILE` options to support self-signed and custom PKI qBitTorrent WebUI endpoints with TLS 1.2+ and connection pooling.
- **HTTP Server Hardening:** Added `LISTEN_ADDR` for interface binding control, `IdleTimeout: 60s`, and `MaxHeaderBytes: 1MB`.