### PR TITLE
feat: observability, probes, Prometheus metrics, and native CLI healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Instead of relying on heavy polling shell scripts, this project provides a **Go-
 - **Secret Management & File Mounts:** Supports secret files (`QBIT_PASS_FILE`, `QBIT_USER_FILE`, `QBIT_API_KEY_FILE`) for Docker Secrets and Kubernetes Secrets integration.
 - **Hardened Container Security:** Runs as unprivileged `nonroot` inside Google's minimal `distroless/static-debian12` image (zero C shared library footprint).
 - **Graceful Lifecycle Management:** Traps `SIGINT`/`SIGTERM` to perform clean draining and termination.
-- **Health Probing:** Exposes `/healthz` for Kubernetes and Docker liveness checks.
+- **Observability & Probes:** Exposes `/healthz` (liveness), `/readyz` (readiness), `/status` (JSON diagnostics), and `/metrics` (Prometheus exposition).
+- **Distroless Native Healthcheck:** Built-in CLI `-healthcheck` flag for native container health checking without `curl` or `sh`.
 
 ## Configuration
 
@@ -63,6 +64,16 @@ The application is configured using Environment Variables, grouped by logical do
 | :--- | :--- | :--- |
 | `SYNC_INTERVAL` | `10m` | Periodic reconciliation interval (e.g. `5m`, `10m`, `0` to disable). |
 | `LOG_LEVEL` | `info` | Log verbosity level (`debug`, `info`, `warn`, `error`). |
+| `LOG_FORMAT` | `text` | Log format: `text` or `json`. |
+
+## API & Health Endpoints
+
+| Endpoint | Method | Description |
+| :--- | :--- | :--- |
+| `/healthz` | `GET` | **Liveness probe.** Returns `200 OK` as long as the process is alive. |
+| `/readyz` | `GET` | **Readiness probe.** Returns `200 OK` when initial sync is complete and qBitTorrent is reachable, `503 Service Unavailable` otherwise. |
+| `/status` | `GET` | **Diagnostics.** Returns a detailed JSON payload with sync status, current port, timestamps, and error counters. |
+| `/metrics` | `GET` | **Prometheus metrics.** Exposes `qbit_gluetun_sync_current_port`, `qbit_gluetun_sync_operations_total`, and `qbit_gluetun_sync_qbittorrent_reachable`. |
 
 ## Usage
 
@@ -108,11 +119,17 @@ services:
       - PORT_FILE=/tmp/gluetun/forwarded_port
       - LISTEN_PORT=9090
       - SYNC_INTERVAL=10m
+      - LOG_FORMAT=json
     volumes:
       - gluetun_data:/tmp/gluetun:ro
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/qbit-gluetun-sync", "-healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
 ```
 
-### Kubernetes (Sidecar Pattern with Secrets)
+### Kubernetes (Sidecar Pattern with Probes and Secrets)
 
 If deploying in Kubernetes, deploy inside the same Pod as qBitTorrent with an `emptyDir` volume shared with Gluetun and mounted Secrets.
 
@@ -149,6 +166,8 @@ spec:
               value: "http://localhost:8080"
             - name: QBIT_PASS_FILE
               value: "/etc/secrets/qbit/password"
+            - name: LOG_FORMAT
+              value: "json"
           ports:
             - containerPort: 9090
               name: healthz
@@ -163,6 +182,10 @@ spec:
             httpGet:
               path: /healthz
               port: 9090
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9090
       volumes:
         - name: gluetun-sync
           emptyDir: {}
@@ -170,10 +193,6 @@ spec:
           secret:
             secretName: qbit-credentials
 ```
-
-## API Endpoints
-
-- `GET /healthz` - Returns `200 OK` if the sidecar is running.
 
 ## Development
 

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -19,17 +21,137 @@ import (
 	"github.com/hononeko/qbit-gluetun-sync/pkg/watcher"
 )
 
-var (
-	currentPort int
-	portMu      sync.Mutex
-)
+// SyncState tracks real-time sync metrics and upstream health.
+type SyncState struct {
+	mu                     sync.RWMutex
+	currentPort            int
+	lastSuccessTime        time.Time
+	lastAttemptTime        time.Time
+	lastSyncErr            string
+	syncSuccessCount       int64
+	syncFailureCount       int64
+	qbittorrentReachable   bool
+	initialSyncDone        bool
+	reconciliationInterval time.Duration
+}
+
+func (s *SyncState) recordSuccess(port int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	s.currentPort = port
+	s.lastSuccessTime = now
+	s.lastAttemptTime = now
+	s.lastSyncErr = ""
+	s.syncSuccessCount++
+	s.qbittorrentReachable = true
+	s.initialSyncDone = true
+}
+
+func (s *SyncState) recordFailure(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastAttemptTime = time.Now().UTC()
+	if err != nil {
+		s.lastSyncErr = err.Error()
+	}
+	s.syncFailureCount++
+	s.qbittorrentReachable = false
+}
+
+func (s *SyncState) isReady() (bool, string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.initialSyncDone {
+		return false, "waiting for initial port synchronization"
+	}
+	if !s.qbittorrentReachable {
+		return false, fmt.Sprintf("qbittorrent unreachable (last error: %s)", s.lastSyncErr)
+	}
+	return true, ""
+}
+
+func (s *SyncState) getStatus() map[string]interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	status := "synced"
+	if !s.initialSyncDone {
+		status = "waiting_for_initial_sync"
+	} else if !s.qbittorrentReachable {
+		status = "degraded"
+	}
+
+	res := map[string]interface{}{
+		"status":                  status,
+		"current_port":            s.currentPort,
+		"last_sync_error":         s.lastSyncErr,
+		"sync_success_count":      s.syncSuccessCount,
+		"sync_failure_count":      s.syncFailureCount,
+		"qbittorrent_reachable":   s.qbittorrentReachable,
+		"initial_sync_done":       s.initialSyncDone,
+		"reconciliation_interval": s.reconciliationInterval.String(),
+	}
+	if !s.lastSuccessTime.IsZero() {
+		res["last_success_time"] = s.lastSuccessTime.Format(time.RFC3339)
+	}
+	if !s.lastAttemptTime.IsZero() {
+		res["last_attempt_time"] = s.lastAttemptTime.Format(time.RFC3339)
+	}
+	return res
+}
+
+func (s *SyncState) getMetrics() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var lastSuccessTimestamp int64
+	if !s.lastSuccessTime.IsZero() {
+		lastSuccessTimestamp = s.lastSuccessTime.Unix()
+	}
+
+	reachableVal := 0
+	if s.qbittorrentReachable {
+		reachableVal = 1
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# HELP qbit_gluetun_sync_current_port Currently configured listening port in qBitTorrent\n")
+	sb.WriteString("# TYPE qbit_gluetun_sync_current_port gauge\n")
+	fmt.Fprintf(&sb, "qbit_gluetun_sync_current_port %d\n\n", s.currentPort)
+
+	sb.WriteString("# HELP qbit_gluetun_sync_operations_total Total number of port sync attempts\n")
+	sb.WriteString("# TYPE qbit_gluetun_sync_operations_total counter\n")
+	fmt.Fprintf(&sb, "qbit_gluetun_sync_operations_total{status=\"success\"} %d\n", s.syncSuccessCount)
+	fmt.Fprintf(&sb, "qbit_gluetun_sync_operations_total{status=\"failure\"} %d\n\n", s.syncFailureCount)
+
+	sb.WriteString("# HELP qbit_gluetun_sync_last_success_timestamp_seconds Unix timestamp of last successful sync\n")
+	sb.WriteString("# TYPE qbit_gluetun_sync_last_success_timestamp_seconds gauge\n")
+	fmt.Fprintf(&sb, "qbit_gluetun_sync_last_success_timestamp_seconds %d\n\n", lastSuccessTimestamp)
+
+	sb.WriteString("# HELP qbit_gluetun_sync_qbittorrent_reachable Whether qBitTorrent is currently reachable (1 for reachable, 0 for unreachable)\n")
+	sb.WriteString("# TYPE qbit_gluetun_sync_qbittorrent_reachable gauge\n")
+	fmt.Fprintf(&sb, "qbit_gluetun_sync_qbittorrent_reachable %d\n", reachableVal)
+
+	return sb.String()
+}
 
 func main() {
+	// Parse CLI healthcheck flag before service startup
+	listenAddr := getEnv("LISTEN_ADDR", "")
+	listenPort := getEnv("LISTEN_PORT", "9090")
+
+	if isHealthCheckMode(os.Args) {
+		code := runCLIHealthCheck(listenAddr, listenPort)
+		os.Exit(code)
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	logLevel := getEnv("LOG_LEVEL", "info")
-	logger.Init(logLevel)
+	logFormat := getEnv("LOG_FORMAT", "text")
+	logger.InitWithFormat(logLevel, logFormat)
 
 	// Parse environment variables and secret files
 	qbitAddr := getEnv("QBIT_ADDR", "http://localhost:8080")
@@ -38,8 +160,6 @@ func main() {
 	qbitAPIKey := getSecret("QBIT_API_KEY", "QBIT_API_KEY_FILE", "")
 	qbitAPIKeyHeader := getEnv("QBIT_API_KEY_HEADER", "X-Api-Key")
 	portFile := getEnv("PORT_FILE", "/tmp/gluetun/forwarded_port")
-	listenAddr := getEnv("LISTEN_ADDR", "")
-	listenPort := getEnv("LISTEN_PORT", "9090")
 	syncIntervalStr := getEnv("SYNC_INTERVAL", "10m")
 	insecureSkipVerifyStr := getEnv("QBIT_INSECURE_SKIP_VERIFY", "false")
 	caCertFile := getEnv("QBIT_CA_CERT_FILE", "")
@@ -50,6 +170,10 @@ func main() {
 	if err != nil {
 		logger.Warn("Invalid SYNC_INTERVAL format, defaulting to 10m", "val", syncIntervalStr, "err", err)
 		syncInterval = 10 * time.Minute
+	}
+
+	state := &SyncState{
+		reconciliationInterval: syncInterval,
 	}
 
 	// Initialize qBitTorrent Client with security/TLS/Auth options
@@ -67,13 +191,13 @@ func main() {
 
 	// Callback to sync port
 	syncPortFunc := func(port int) {
-		portMu.Lock()
-		if port == currentPort {
-			portMu.Unlock()
+		state.mu.RLock()
+		if port == state.currentPort && state.qbittorrentReachable {
+			state.mu.RUnlock()
 			logger.Debug("Port is already synced, skipping", "port", port)
 			return
 		}
-		portMu.Unlock()
+		state.mu.RUnlock()
 
 		logger.Info("Syncing new port to qBitTorrent", "port", port)
 
@@ -90,9 +214,7 @@ func main() {
 			syncErr = qbitClient.SetListenPort(ctx, port)
 			if syncErr == nil {
 				logger.Info("Successfully set port in qBitTorrent", "port", port)
-				portMu.Lock()
-				currentPort = port
-				portMu.Unlock()
+				state.recordSuccess(port)
 				return
 			}
 
@@ -108,6 +230,7 @@ func main() {
 			}
 		}
 
+		state.recordFailure(syncErr)
 		logger.Error("Exhausted all retries. Failed to sync port to qBitTorrent", "port", port, "err", syncErr)
 	}
 
@@ -126,7 +249,7 @@ func main() {
 		go runReconciliationLoop(ctx, portFile, syncPortFunc, syncInterval)
 	}
 
-	mux := setupMux()
+	mux := setupMux(state)
 	bindAddr := net.JoinHostPort(listenAddr, listenPort)
 
 	logger.Info("Starting sidecar server", "bindAddr", bindAddr, "qbitAddr", qbitAddr)
@@ -182,19 +305,111 @@ func runReconciliationLoop(ctx context.Context, portFile string, syncPortFunc fu
 	}
 }
 
-func setupMux() *http.ServeMux {
+func setupMux(state *SyncState) *http.ServeMux {
 	mux := http.NewServeMux()
+
+	// /healthz - Liveness probe
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte("OK")); err != nil {
-			logger.Error("Failed to write healthz response", "err", err)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	// /readyz - Readiness probe
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if state == nil {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+			return
+		}
+		ready, reason := state.isReady()
+		if ready {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("READY"))
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprintf(w, "NOT READY: %s", reason)
+	})
+
+	// /status - JSON diagnostic endpoint
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if state != nil {
+			_ = json.NewEncoder(w).Encode(state.getStatus())
+		} else {
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 		}
 	})
+
+	// /metrics - Prometheus exposition endpoint
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		if state != nil {
+			_, _ = w.Write([]byte(state.getMetrics()))
+		}
+	})
+
 	return mux
+}
+
+func isHealthCheckMode(args []string) bool {
+	for _, arg := range args[1:] {
+		if arg == "-healthcheck" || arg == "--healthcheck" {
+			return true
+		}
+	}
+	return false
+}
+
+func runCLIHealthCheck(listenAddr, listenPort string) int {
+	host := listenAddr
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	targetURL := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, listenPort))
+
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Health check error creating request: %v\n", err)
+		return 1
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Health check failed: %v\n", err)
+		return 1
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("Health check OK")
+		return 0
+	}
+
+	fmt.Fprintf(os.Stderr, "Health check returned status: %d\n", resp.StatusCode)
+	return 1
 }
 
 func getEnv(key, fallback string) string {

--- a/cmd/sync/main_test.go
+++ b/cmd/sync/main_test.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -25,7 +29,7 @@ func TestHealthCheck(t *testing.T) {
 	}
 
 	rr := httptest.NewRecorder()
-	mux := setupMux()
+	mux := setupMux(nil)
 
 	mux.ServeHTTP(rr, req)
 
@@ -47,6 +51,155 @@ func TestHealthCheck(t *testing.T) {
 
 	if status := rrPost.Code; status != http.StatusMethodNotAllowed {
 		t.Errorf("handler returned wrong status code for POST: got %v want %v", status, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestReadyz(t *testing.T) {
+	state := &SyncState{}
+	mux := setupMux(state)
+
+	// 1. Initial state (not ready)
+	req, _ := http.NewRequest(http.MethodGet, "/readyz", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 on uninitialized state, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "waiting for initial port synchronization") {
+		t.Errorf("expected reason in body, got: %s", rr.Body.String())
+	}
+
+	// 2. Success recorded -> Ready
+	state.recordSuccess(12345)
+	rr2 := httptest.NewRecorder()
+	mux.ServeHTTP(rr2, req)
+	if rr2.Code != http.StatusOK {
+		t.Errorf("expected status 200 after success, got %d", rr2.Code)
+	}
+	if rr2.Body.String() != "READY" {
+		t.Errorf("expected body READY, got %s", rr2.Body.String())
+	}
+
+	// 3. Failure recorded -> Degraded / Not Ready
+	state.recordFailure(errors.New("connection timeout"))
+	rr3 := httptest.NewRecorder()
+	mux.ServeHTTP(rr3, req)
+	if rr3.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 after failure, got %d", rr3.Code)
+	}
+	if !strings.Contains(rr3.Body.String(), "qbittorrent unreachable") {
+		t.Errorf("expected failure error in body, got: %s", rr3.Body.String())
+	}
+}
+
+func TestStatusEndpoint(t *testing.T) {
+	state := &SyncState{
+		reconciliationInterval: 10 * time.Minute,
+	}
+	state.recordSuccess(34567)
+
+	mux := setupMux(state)
+	req, _ := http.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %s", ct)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &data); err != nil {
+		t.Fatalf("failed to decode JSON status: %v", err)
+	}
+
+	if data["status"] != "synced" {
+		t.Errorf("expected status synced, got %v", data["status"])
+	}
+	if port, ok := data["current_port"].(float64); !ok || int(port) != 34567 {
+		t.Errorf("expected current_port 34567, got %v", data["current_port"])
+	}
+	if reachable, ok := data["qbittorrent_reachable"].(bool); !ok || !reachable {
+		t.Errorf("expected qbittorrent_reachable true, got %v", data["qbittorrent_reachable"])
+	}
+	if _, ok := data["last_success_time"].(string); !ok {
+		t.Errorf("expected last_success_time in status")
+	}
+}
+
+func TestMetricsEndpoint(t *testing.T) {
+	state := &SyncState{}
+	state.recordSuccess(45678)
+	state.recordFailure(errors.New("temporary error"))
+
+	mux := setupMux(state)
+	req, _ := http.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "qbit_gluetun_sync_current_port 45678") {
+		t.Errorf("metrics missing current_port: %s", body)
+	}
+	if !strings.Contains(body, `qbit_gluetun_sync_operations_total{status="success"} 1`) {
+		t.Errorf("metrics missing success count: %s", body)
+	}
+	if !strings.Contains(body, `qbit_gluetun_sync_operations_total{status="failure"} 1`) {
+		t.Errorf("metrics missing failure count: %s", body)
+	}
+	if !strings.Contains(body, "qbit_gluetun_sync_qbittorrent_reachable 0") {
+		t.Errorf("metrics missing qbittorrent_reachable 0: %s", body)
+	}
+	if !strings.Contains(body, "qbit_gluetun_sync_last_success_timestamp_seconds") {
+		t.Errorf("metrics missing last_success_timestamp_seconds: %s", body)
+	}
+}
+
+func TestHealthCheckModeAndCLI(t *testing.T) {
+	if !isHealthCheckMode([]string{"app", "-healthcheck"}) {
+		t.Errorf("expected true for -healthcheck")
+	}
+	if !isHealthCheckMode([]string{"app", "--healthcheck"}) {
+		t.Errorf("expected true for --healthcheck")
+	}
+	if isHealthCheckMode([]string{"app", "normal_arg"}) {
+		t.Errorf("expected false for normal_arg")
+	}
+
+	// Test CLI against test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split host/port: %v", err)
+	}
+
+	exitCode := runCLIHealthCheck("127.0.0.1", port)
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0 for healthy server, got %d", exitCode)
+	}
+
+	// Test bad port
+	exitCodeBad := runCLIHealthCheck("127.0.0.1", "1")
+	if exitCodeBad != 1 {
+		t.Errorf("expected exit code 1 for unreachable server, got %d", exitCodeBad)
 	}
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,15 +1,33 @@
 package logger
 
 import (
+	"io"
 	"log/slog"
 	"os"
 	"strings"
+	"sync/atomic"
 )
 
-var internalLogger *slog.Logger
+var internalLogger atomic.Pointer[slog.Logger]
 
-// Init initializes the global logger with the specified level.
+func init() {
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	defaultLogger := slog.New(slog.NewTextHandler(os.Stdout, opts))
+	internalLogger.Store(defaultLogger)
+}
+
+// Init initializes the global logger with the specified level and format.
 func Init(levelStr string) {
+	InitWithFormat(levelStr, "text")
+}
+
+// InitWithFormat initializes the global logger with level and format ("text" or "json").
+func InitWithFormat(levelStr, formatStr string) {
+	InitWithWriter(levelStr, formatStr, os.Stdout)
+}
+
+// InitWithWriter initializes the global logger with level, format, and custom output writer (useful for tests).
+func InitWithWriter(levelStr, formatStr string, w io.Writer) {
 	var level slog.Level
 	switch strings.ToLower(levelStr) {
 	case "debug":
@@ -27,18 +45,26 @@ func Init(levelStr string) {
 	opts := &slog.HandlerOptions{
 		Level: level,
 	}
-	handler := slog.NewTextHandler(os.Stdout, opts)
-	internalLogger = slog.New(handler)
+
+	var handler slog.Handler
+	if strings.EqualFold(formatStr, "json") {
+		handler = slog.NewJSONHandler(w, opts)
+	} else {
+		handler = slog.NewTextHandler(w, opts)
+	}
+
+	internalLogger.Store(slog.New(handler))
 }
 
-// Ensure the logger falls back to standard log behavior if not initialized
 func getDefault() *slog.Logger {
-	if internalLogger != nil {
-		return internalLogger
+	l := internalLogger.Load()
+	if l != nil {
+		return l
 	}
-	// Fallback during tests or early init
 	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
-	return slog.New(slog.NewTextHandler(os.Stdout, opts))
+	fallback := slog.New(slog.NewTextHandler(os.Stdout, opts))
+	internalLogger.Store(fallback)
+	return fallback
 }
 
 // Info logs an informational message.

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,47 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestLogger_TextFormat(t *testing.T) {
+	var buf bytes.Buffer
+	InitWithWriter("debug", "text", &buf)
+
+	Info("test info message", "key", "val")
+	output := buf.String()
+	if !strings.Contains(output, "level=INFO") || !strings.Contains(output, "msg=\"test info message\"") || !strings.Contains(output, "key=val") {
+		t.Fatalf("unexpected text log output: %s", output)
+	}
+
+	buf.Reset()
+	Debug("test debug message")
+	if !strings.Contains(buf.String(), "level=DEBUG") {
+		t.Fatalf("expected debug message, got %s", buf.String())
+	}
+}
+
+func TestLogger_JSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	InitWithWriter("info", "json", &buf)
+
+	Warn("test warning", "attempt", 2)
+
+	var logEntry map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+		t.Fatalf("failed to unmarshal JSON log: %v, raw output: %s", err, buf.String())
+	}
+
+	if logEntry["msg"] != "test warning" {
+		t.Errorf("expected msg 'test warning', got %v", logEntry["msg"])
+	}
+	if logEntry["level"] != "WARN" {
+		t.Errorf("expected level 'WARN', got %v", logEntry["level"])
+	}
+	if attempt, ok := logEntry["attempt"].(float64); !ok || int(attempt) != 2 {
+		t.Errorf("expected attempt 2, got %v", logEntry["attempt"])
+	}
+}


### PR DESCRIPTION
## Summary
Implements Phase 3 observability and container lifecycle probing:

- **Observability Endpoints:**
  - `GET /healthz`: Liveness probe.
  - `GET /readyz`: Readiness probe checking initial sync and qBitTorrent reachability.
  - `GET /status`: Detailed JSON diagnostic payload with timestamps and error states.
  - `GET /metrics`: Prometheus plain-text metrics (`current_port`, `operations_total`, `last_success_timestamp_seconds`, `qbittorrent_reachable`).
- **Distroless Native Healthcheck Flag (`-healthcheck`):** Allows running native container health checks in Distroless without requiring `curl` or `sh`.
- **Structured JSON Logging:** Added `LOG_FORMAT=json|text` support in `pkg/logger` with `atomic.Pointer` thread safety.
- **Sync Metrics Tracking:** Added `SyncState` to monitor sync attempts, upstream reachability, and success timestamps.