### PR TITLE
feat: Gluetun REST API client, webhook notifications, UPnP control, and /sync endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ When using VPN providers like ProtonVPN with WireGuard through [Gluetun](https:/
 
 Instead of relying on heavy polling shell scripts, this project provides a **Go-based sidecar** that:
 
-- **Resilient File Watching:** Watches the `/tmp/gluetun/forwarded_port` file using `fsnotify` for instant updates. Automatically detects delayed directory creation and handles volume remounts gracefully.
+- **Resilient File Watching & REST API:** Watches the `/tmp/gluetun/forwarded_port` file using `fsnotify` and optionally polls Gluetun's REST API (`GLUETUN_ADDR`) as a dynamic fallback or alternative source.
 - **Self-Healing Reconciliation:** Runs a periodic reconciliation loop (`SYNC_INTERVAL`) to ensure qBitTorrent stays synchronized even after container reboots or network blips.
 - **Flexible Authentication:** Supports standard username/password sessions as well as API Key / Bearer tokens (`QBIT_API_KEY`, `QBIT_API_KEY_FILE`).
 - **Secret Management & File Mounts:** Supports secret files (`QBIT_PASS_FILE`, `QBIT_USER_FILE`, `QBIT_API_KEY_FILE`) for Docker Secrets and Kubernetes Secrets integration.
+- **Webhook Notifications:** Dispatches HTTP POST notifications to Discord or generic webhook endpoints (`WEBHOOK_URL`) on forwarded port updates.
+- **Manual Sync Webhook:** Exposes `POST /sync` to allow external tools and CI pipelines to trigger immediate synchronization.
 - **Hardened Container Security:** Runs as unprivileged `nonroot` inside Google's minimal `distroless/static-debian12` image (zero C shared library footprint).
-- **Graceful Lifecycle Management:** Traps `SIGINT`/`SIGTERM` to perform clean draining and termination.
 - **Observability & Probes:** Exposes `/healthz` (liveness), `/readyz` (readiness), `/status` (JSON diagnostics), and `/metrics` (Prometheus exposition).
 - **Distroless Native Healthcheck:** Built-in CLI `-healthcheck` flag for native container health checking without `curl` or `sh`.
 
@@ -43,6 +44,14 @@ The application is configured using Environment Variables, grouped by logical do
 | `QBIT_API_KEY` | _(empty)_ | API Key / Bearer token for qBitTorrent (bypasses cookie login). |
 | `QBIT_API_KEY_FILE` | _(empty)_ | File path to read API Key from (takes precedence over `QBIT_API_KEY`). |
 | `QBIT_API_KEY_HEADER` | `X-Api-Key` | Custom HTTP header name used when sending API Key. |
+
+### Integrations & Webhooks (Optional)
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `GLUETUN_ADDR` | _(empty)_ | URL to Gluetun Control Server REST API (e.g. `http://gluetun:8000`). |
+| `WEBHOOK_URL` | _(empty)_ | Webhook URL (Discord or generic JSON) to notify when forwarded port changes. |
+| `QBIT_DISABLE_UPNP` | `false` | When `true`, explicitly disables UPnP (`upnp: false`) in qBitTorrent preferences. |
 
 ### TLS & Network Security (Optional)
 
@@ -74,6 +83,7 @@ The application is configured using Environment Variables, grouped by logical do
 | `/readyz` | `GET` | **Readiness probe.** Returns `200 OK` when initial sync is complete and qBitTorrent is reachable, `503 Service Unavailable` otherwise. |
 | `/status` | `GET` | **Diagnostics.** Returns a detailed JSON payload with sync status, current port, timestamps, and error counters. |
 | `/metrics` | `GET` | **Prometheus metrics.** Exposes `qbit_gluetun_sync_current_port`, `qbit_gluetun_sync_operations_total`, and `qbit_gluetun_sync_qbittorrent_reachable`. |
+| `/sync` | `POST` / `GET` | **Manual Sync Trigger.** Forces an immediate source check (file and Gluetun API) and syncs the port to qBitTorrent. |
 
 ## Usage
 
@@ -120,6 +130,8 @@ services:
       - LISTEN_PORT=9090
       - SYNC_INTERVAL=10m
       - LOG_FORMAT=json
+      # Optional: Webhook alert on port changes
+      - WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy
     volumes:
       - gluetun_data:/tmp/gluetun:ro
     healthcheck:

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -16,7 +16,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/hononeko/qbit-gluetun-sync/pkg/gluetun"
 	"github.com/hononeko/qbit-gluetun-sync/pkg/logger"
+	"github.com/hononeko/qbit-gluetun-sync/pkg/notifier"
 	"github.com/hononeko/qbit-gluetun-sync/pkg/qbit"
 	"github.com/hononeko/qbit-gluetun-sync/pkg/watcher"
 )
@@ -160,11 +162,15 @@ func main() {
 	qbitAPIKey := getSecret("QBIT_API_KEY", "QBIT_API_KEY_FILE", "")
 	qbitAPIKeyHeader := getEnv("QBIT_API_KEY_HEADER", "X-Api-Key")
 	portFile := getEnv("PORT_FILE", "/tmp/gluetun/forwarded_port")
+	gluetunAddr := getEnv("GLUETUN_ADDR", "")
+	webhookURL := getEnv("WEBHOOK_URL", "")
 	syncIntervalStr := getEnv("SYNC_INTERVAL", "10m")
 	insecureSkipVerifyStr := getEnv("QBIT_INSECURE_SKIP_VERIFY", "false")
+	disableUPnPStr := getEnv("QBIT_DISABLE_UPNP", "false")
 	caCertFile := getEnv("QBIT_CA_CERT_FILE", "")
 
 	insecureSkipVerify, _ := strconv.ParseBool(insecureSkipVerifyStr)
+	disableUPnP, _ := strconv.ParseBool(disableUPnPStr)
 
 	syncInterval, err := time.ParseDuration(syncIntervalStr)
 	if err != nil {
@@ -176,12 +182,20 @@ func main() {
 		reconciliationInterval: syncInterval,
 	}
 
+	notifierClient := notifier.NewNotifier()
+	var gluetunClient *gluetun.Client
+	if gluetunAddr != "" {
+		logger.Info("Gluetun REST API configured as dynamic sync source", "addr", gluetunAddr)
+		gluetunClient = gluetun.NewClient(gluetunAddr)
+	}
+
 	// Initialize qBitTorrent Client with security/TLS/Auth options
 	qbitOpts := qbit.ClientOptions{
 		InsecureSkipVerify: insecureSkipVerify,
 		CACertFile:         caCertFile,
 		APIKey:             qbitAPIKey,
 		APIKeyHeader:       qbitAPIKeyHeader,
+		DisableUPnP:        disableUPnP,
 		Timeout:            10 * time.Second,
 	}
 	qbitClient, err := qbit.NewClientWithOptions(qbitAddr, qbitUser, qbitPass, qbitOpts)
@@ -192,6 +206,7 @@ func main() {
 	// Callback to sync port
 	syncPortFunc := func(port int) {
 		state.mu.RLock()
+		prevPort := state.currentPort
 		if port == state.currentPort && state.qbittorrentReachable {
 			state.mu.RUnlock()
 			logger.Debug("Port is already synced, skipping", "port", port)
@@ -215,6 +230,19 @@ func main() {
 			if syncErr == nil {
 				logger.Info("Successfully set port in qBitTorrent", "port", port)
 				state.recordSuccess(port)
+
+				// Trigger webhook notification asynchronously on port change
+				if webhookURL != "" && (prevPort != port || prevPort == 0) {
+					go func(pPort, nPort int) {
+						notifyCtx, notifyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer notifyCancel()
+						if notifyErr := notifierClient.SendPortUpdate(notifyCtx, webhookURL, pPort, nPort); notifyErr != nil {
+							logger.Warn("Failed to send webhook notification", "err", notifyErr)
+						} else {
+							logger.Info("Successfully dispatched port change webhook notification", "newPort", nPort)
+						}
+					}(prevPort, port)
+				}
 				return
 			}
 
@@ -234,8 +262,27 @@ func main() {
 		logger.Error("Exhausted all retries. Failed to sync port to qBitTorrent", "port", port, "err", syncErr)
 	}
 
-	// Initial check in case file already exists
-	watcher.CheckFileNow(portFile, syncPortFunc)
+	// Helper to check all available sources (file and/or Gluetun API)
+	checkSourcesFunc := func() {
+		// Check Gluetun API if configured
+		if gluetunClient != nil {
+			gCtx, gCancel := context.WithTimeout(ctx, 5*time.Second)
+			gPort, gErr := gluetunClient.GetForwardedPort(gCtx)
+			gCancel()
+			if gErr == nil && gPort > 0 {
+				logger.Debug("Retrieved forwarded port from Gluetun API", "port", gPort)
+				syncPortFunc(gPort)
+				return
+			}
+			logger.Debug("Gluetun API check failed or returned 0, checking file", "err", gErr)
+		}
+
+		// Check Port File
+		watcher.CheckFileNow(portFile, syncPortFunc)
+	}
+
+	// Initial check on startup
+	checkSourcesFunc()
 
 	// Start file watcher with context lifecycle
 	logger.Info("Starting file watcher", "file", portFile)
@@ -246,10 +293,10 @@ func main() {
 	// Start periodic reconciliation loop if configured
 	if syncInterval > 0 {
 		logger.Info("Starting reconciliation loop", "interval", syncInterval)
-		go runReconciliationLoop(ctx, portFile, syncPortFunc, syncInterval)
+		go runReconciliationLoop(ctx, checkSourcesFunc, syncInterval)
 	}
 
-	mux := setupMux(state)
+	mux := setupMux(state, checkSourcesFunc)
 	bindAddr := net.JoinHostPort(listenAddr, listenPort)
 
 	logger.Info("Starting sidecar server", "bindAddr", bindAddr, "qbitAddr", qbitAddr)
@@ -290,7 +337,7 @@ func main() {
 	}
 }
 
-func runReconciliationLoop(ctx context.Context, portFile string, syncPortFunc func(port int), interval time.Duration) {
+func runReconciliationLoop(ctx context.Context, checkFunc func(), interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -299,13 +346,13 @@ func runReconciliationLoop(ctx context.Context, portFile string, syncPortFunc fu
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			logger.Debug("Reconciliation ticker: checking port file", "file", portFile)
-			watcher.CheckFileNow(portFile, syncPortFunc)
+			logger.Debug("Reconciliation ticker triggering sync check")
+			checkFunc()
 		}
 	}
 }
 
-func setupMux(state *SyncState) *http.ServeMux {
+func setupMux(state *SyncState, triggerSync func()) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// /healthz - Liveness probe
@@ -365,6 +412,29 @@ func setupMux(state *SyncState) *http.ServeMux {
 		if state != nil {
 			_, _ = w.Write([]byte(state.getMetrics()))
 		}
+	})
+
+	// /sync - Manual synchronization trigger
+	mux.HandleFunc("/sync", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost && r.Method != http.MethodGet {
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if triggerSync != nil {
+			triggerSync()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]interface{}{
+			"status": "sync_triggered",
+		}
+		if state != nil {
+			state.mu.RLock()
+			resp["current_port"] = state.currentPort
+			resp["qbittorrent_reachable"] = state.qbittorrentReachable
+			state.mu.RUnlock()
+		}
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 
 	return mux

--- a/cmd/sync/main_test.go
+++ b/cmd/sync/main_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -29,7 +30,7 @@ func TestHealthCheck(t *testing.T) {
 	}
 
 	rr := httptest.NewRecorder()
-	mux := setupMux(nil)
+	mux := setupMux(nil, nil)
 
 	mux.ServeHTTP(rr, req)
 
@@ -56,7 +57,7 @@ func TestHealthCheck(t *testing.T) {
 
 func TestReadyz(t *testing.T) {
 	state := &SyncState{}
-	mux := setupMux(state)
+	mux := setupMux(state, nil)
 
 	// 1. Initial state (not ready)
 	req, _ := http.NewRequest(http.MethodGet, "/readyz", nil)
@@ -99,7 +100,7 @@ func TestStatusEndpoint(t *testing.T) {
 	}
 	state.recordSuccess(34567)
 
-	mux := setupMux(state)
+	mux := setupMux(state, nil)
 	req, _ := http.NewRequest(http.MethodGet, "/status", nil)
 	rr := httptest.NewRecorder()
 
@@ -136,7 +137,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	state.recordSuccess(45678)
 	state.recordFailure(errors.New("temporary error"))
 
-	mux := setupMux(state)
+	mux := setupMux(state, nil)
 	req, _ := http.NewRequest(http.MethodGet, "/metrics", nil)
 	rr := httptest.NewRecorder()
 
@@ -161,6 +162,41 @@ func TestMetricsEndpoint(t *testing.T) {
 	}
 	if !strings.Contains(body, "qbit_gluetun_sync_last_success_timestamp_seconds") {
 		t.Errorf("metrics missing last_success_timestamp_seconds: %s", body)
+	}
+}
+
+func TestManualSyncEndpoint(t *testing.T) {
+	var triggered int32
+	triggerSync := func() {
+		atomic.AddInt32(&triggered, 1)
+	}
+
+	state := &SyncState{}
+	state.recordSuccess(55555)
+
+	mux := setupMux(state, triggerSync)
+
+	req, _ := http.NewRequest(http.MethodPost, "/sync", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK from POST /sync, got %d", rr.Code)
+	}
+
+	if val := atomic.LoadInt32(&triggered); val != 1 {
+		t.Errorf("expected triggerSync to be called once, got %d", val)
+	}
+
+	var res map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &res); err != nil {
+		t.Fatalf("failed to decode json response: %v", err)
+	}
+	if res["status"] != "sync_triggered" {
+		t.Errorf("expected status sync_triggered, got %v", res["status"])
+	}
+	if port, ok := res["current_port"].(float64); !ok || int(port) != 55555 {
+		t.Errorf("expected current_port 55555, got %v", res["current_port"])
 	}
 }
 
@@ -248,24 +284,15 @@ func TestGetSecret(t *testing.T) {
 }
 
 func TestReconciliationLoop(t *testing.T) {
-	tempDir := t.TempDir()
-	portFile := filepath.Join(tempDir, "forwarded_port")
-
-	if err := os.WriteFile(portFile, []byte("44444\n"), 0600); err != nil {
-		t.Fatalf("failed to write test port file: %v", err)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	triggerCh := make(chan struct{}, 5)
-	syncFunc := func(port int) {
-		if port == 44444 {
-			triggerCh <- struct{}{}
-		}
+	syncFunc := func() {
+		triggerCh <- struct{}{}
 	}
 
-	go runReconciliationLoop(ctx, portFile, syncFunc, 10*time.Millisecond)
+	go runReconciliationLoop(ctx, syncFunc, 10*time.Millisecond)
 
 	// Wait for at least 2 triggers deterministically
 	for i := 0; i < 2; i++ {

--- a/pkg/gluetun/client.go
+++ b/pkg/gluetun/client.go
@@ -1,0 +1,89 @@
+package gluetun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Client interacts with the Gluetun Control Server REST API.
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// NewClient creates a new Gluetun API client.
+func NewClient(baseURL string) *Client {
+	return &Client{
+		BaseURL: baseURL,
+		HTTPClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+type portResponse struct {
+	Port int `json:"port"`
+}
+
+// GetForwardedPort queries the Gluetun API for the current forwarded port.
+func (c *Client) GetForwardedPort(ctx context.Context) (int, error) {
+	if c.BaseURL == "" {
+		return 0, fmt.Errorf("gluetun base URL is empty")
+	}
+
+	apiURL, err := url.JoinPath(c.BaseURL, "/v1/openvpn/portforwarded")
+	if err != nil {
+		return 0, fmt.Errorf("failed to construct gluetun portforwarded URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create gluetun request: %w", err)
+	}
+
+	//nolint:gosec // URL is internally constructed via config
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("gluetun API request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("gluetun API returned status: %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	if err != nil {
+		return 0, fmt.Errorf("failed to read gluetun API response: %w", err)
+	}
+
+	trimmed := strings.TrimSpace(string(bodyBytes))
+
+	// Try parsing JSON payload {"port": 12345}
+	var pr portResponse
+	if jsonErr := json.Unmarshal([]byte(trimmed), &pr); jsonErr == nil && pr.Port > 0 {
+		if pr.Port > 65535 {
+			return 0, fmt.Errorf("port %d out of valid range (1-65535)", pr.Port)
+		}
+		return pr.Port, nil
+	}
+
+	// Fallback to plain integer parsing
+	port, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse port from gluetun response %q: %w", trimmed, err)
+	}
+
+	if port <= 0 || port > 65535 {
+		return 0, fmt.Errorf("port %d out of valid range (1-65535)", port)
+	}
+
+	return port, nil
+}

--- a/pkg/gluetun/client_test.go
+++ b/pkg/gluetun/client_test.go
@@ -1,0 +1,69 @@
+package gluetun
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClient_GetForwardedPort(t *testing.T) {
+	// Mock Gluetun Server returning JSON
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/openvpn/portforwarded" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"port": 54321}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := NewClient(server.URL)
+	port, err := client.GetForwardedPort(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if port != 54321 {
+		t.Fatalf("expected port 54321, got %d", port)
+	}
+
+	// Mock Server returning plain integer string
+	plainServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("61234\n"))
+	}))
+	defer plainServer.Close()
+
+	plainClient := NewClient(plainServer.URL)
+	plainPort, err := plainClient.GetForwardedPort(ctx)
+	if err != nil {
+		t.Fatalf("expected no error on plain integer, got %v", err)
+	}
+	if plainPort != 61234 {
+		t.Fatalf("expected port 61234, got %d", plainPort)
+	}
+
+	// Mock 500 error
+	errServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer errServer.Close()
+
+	errClient := NewClient(errServer.URL)
+	_, err = errClient.GetForwardedPort(ctx)
+	if err == nil {
+		t.Fatalf("expected error on 500 status, got nil")
+	}
+
+	// Empty URL
+	emptyClient := NewClient("")
+	_, err = emptyClient.GetForwardedPort(ctx)
+	if err == nil {
+		t.Fatalf("expected error on empty URL, got nil")
+	}
+}

--- a/pkg/notifier/webhook.go
+++ b/pkg/notifier/webhook.go
@@ -1,0 +1,102 @@
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Notifier dispatches port update notifications to configured webhooks.
+type Notifier struct {
+	HTTPClient *http.Client
+}
+
+// NewNotifier creates a new webhook notifier.
+func NewNotifier() *Notifier {
+	return &Notifier{
+		HTTPClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+type genericPayload struct {
+	Event        string `json:"event"`
+	PreviousPort int    `json:"previous_port"`
+	NewPort      int    `json:"new_port"`
+	Timestamp    string `json:"timestamp"`
+}
+
+type discordEmbed struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Color       int    `json:"color"`
+	Timestamp   string `json:"timestamp"`
+}
+
+type discordPayload struct {
+	Username string         `json:"username,omitempty"`
+	Embeds   []discordEmbed `json:"embeds"`
+}
+
+// SendPortUpdate sends a webhook notification with the new forwarded port.
+func (n *Notifier) SendPortUpdate(ctx context.Context, webhookURL string, prevPort, newPort int) error {
+	trimmedURL := strings.TrimSpace(webhookURL)
+	if trimmedURL == "" {
+		return nil // No-op if webhook is not configured
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	var body []byte
+	var err error
+
+	if strings.Contains(trimmedURL, "discord.com/api/webhooks") {
+		payload := discordPayload{
+			Username: "qBit-Gluetun Sync",
+			Embeds: []discordEmbed{
+				{
+					Title:       "Forwarded Port Updated",
+					Description: fmt.Sprintf("qBitTorrent listening port successfully updated from `%d` to `%d`.", prevPort, newPort),
+					Color:       3066993, // Green
+					Timestamp:   now,
+				},
+			},
+		}
+		body, err = json.Marshal(payload)
+	} else {
+		payload := genericPayload{
+			Event:        "port_synced",
+			PreviousPort: prevPort,
+			NewPort:      newPort,
+			Timestamp:    now,
+		}
+		body, err = json.Marshal(payload)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to marshal webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, trimmedURL, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("failed to create webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	//nolint:gosec // URL is user-configured webhook endpoint
+	resp, err := n.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute webhook request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook responded with non-2xx status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/notifier/webhook_test.go
+++ b/pkg/notifier/webhook_test.go
@@ -1,0 +1,86 @@
+package notifier
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNotifier_SendPortUpdate_Generic(t *testing.T) {
+	var receivedPayload map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &receivedPayload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier()
+	err := n.SendPortUpdate(ctx, server.URL, 11111, 22222)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if receivedPayload["event"] != "port_synced" {
+		t.Errorf("expected event 'port_synced', got %v", receivedPayload["event"])
+	}
+	if p, ok := receivedPayload["previous_port"].(float64); !ok || int(p) != 11111 {
+		t.Errorf("expected previous_port 11111, got %v", receivedPayload["previous_port"])
+	}
+	if n, ok := receivedPayload["new_port"].(float64); !ok || int(n) != 22222 {
+		t.Errorf("expected new_port 22222, got %v", receivedPayload["new_port"])
+	}
+}
+
+func TestNotifier_SendPortUpdate_Discord(t *testing.T) {
+	var bodyBytes []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier()
+	discordURL := server.URL + "/discord.com/api/webhooks/test"
+	err := n.SendPortUpdate(ctx, discordURL, 33333, 44444)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	bodyStr := string(bodyBytes)
+	if !strings.Contains(bodyStr, "qBit-Gluetun Sync") || !strings.Contains(bodyStr, "Forwarded Port Updated") {
+		t.Errorf("expected discord embed structure, got: %s", bodyStr)
+	}
+}
+
+func TestNotifier_EmptyURL(t *testing.T) {
+	n := NewNotifier()
+	err := n.SendPortUpdate(context.Background(), "", 1, 2)
+	if err != nil {
+		t.Fatalf("expected nil for empty URL, got %v", err)
+	}
+}
+
+func TestNotifier_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	n := NewNotifier()
+	err := n.SendPortUpdate(context.Background(), server.URL, 1, 2)
+	if err == nil {
+		t.Fatalf("expected error on 400 response, got nil")
+	}
+}

--- a/pkg/qbit/client.go
+++ b/pkg/qbit/client.go
@@ -25,6 +25,7 @@ type ClientOptions struct {
 	//nolint:gosec // Field name for API token
 	APIKey       string
 	APIKeyHeader string
+	DisableUPnP  bool
 }
 
 // Client handles communication with the qBitTorrent API.
@@ -36,6 +37,7 @@ type Client struct {
 	//nolint:gosec // Field name for API token
 	APIKey       string
 	APIKeyHeader string
+	DisableUPnP  bool
 	HTTPClient   *http.Client
 }
 
@@ -45,7 +47,7 @@ func NewClient(baseURL, user, pass string) *Client {
 	return client
 }
 
-// NewClientWithOptions creates a new qBitTorrent client with custom TLS, timeout, and API Key options.
+// NewClientWithOptions creates a new qBitTorrent client with custom TLS, timeout, API Key, and UPnP options.
 func NewClientWithOptions(baseURL, user, pass string, opts ClientOptions) (*Client, error) {
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
@@ -98,6 +100,7 @@ func NewClientWithOptions(baseURL, user, pass string, opts ClientOptions) (*Clie
 		Password:     pass,
 		APIKey:       strings.TrimSpace(opts.APIKey),
 		APIKeyHeader: authHeaderName,
+		DisableUPnP:  opts.DisableUPnP,
 		HTTPClient: &http.Client{
 			Transport: transport,
 			Timeout:   timeout,
@@ -264,7 +267,7 @@ func (c *Client) GetPreferences(ctx context.Context) (map[string]interface{}, er
 	return prefs, nil
 }
 
-// SetListenPort sets the listen port in qBitTorrent with validation.
+// SetListenPort sets the listen port in qBitTorrent with validation, optionally disabling UPnP.
 func (c *Client) SetListenPort(ctx context.Context, port int) error {
 	if port <= 0 || port > 65535 {
 		return fmt.Errorf("invalid port number: %d (must be between 1 and 65535)", port)
@@ -272,6 +275,9 @@ func (c *Client) SetListenPort(ctx context.Context, port int) error {
 
 	prefs := map[string]interface{}{
 		"listen_port": port,
+	}
+	if c.DisableUPnP {
+		prefs["upnp"] = false
 	}
 	return c.SetPreferences(ctx, prefs)
 }

--- a/pkg/qbit/client_test.go
+++ b/pkg/qbit/client_test.go
@@ -119,6 +119,39 @@ func TestClient_SetListenPort(t *testing.T) {
 	}
 }
 
+func TestClient_DisableUPnP(t *testing.T) {
+	var receivedPrefs map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/app/setPreferences" {
+			_ = r.ParseForm()
+			_ = json.Unmarshal([]byte(r.FormValue("json")), &receivedPrefs)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewClientWithOptions(server.URL, "", "", ClientOptions{
+		DisableUPnP: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	err = client.SetListenPort(ctx, 33333)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if upnp, ok := receivedPrefs["upnp"].(bool); !ok || upnp {
+		t.Errorf("expected upnp to be false in payload, got %v", receivedPrefs["upnp"])
+	}
+}
+
 func TestClient_APIKeyAuth(t *testing.T) {
 	// Mock Server with API Key Verification
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
Implements Phase 4 extended integrations and automation features:

- **Gluetun REST API Client (`GLUETUN_ADDR`):** Adds `pkg/gluetun` client to dynamically retrieve forwarded ports directly from Gluetun's REST API (`/v1/openvpn/portforwarded`) as an alternative/fallback to file watching.
- **Port Change Webhook Notifications (`WEBHOOK_URL`):** Adds `pkg/notifier` to dispatch non-blocking, asynchronous HTTP POST notifications on port changes, supporting Discord rich embeds and generic event JSON schemas.
- **Manual Sync Webhook Endpoint (`POST /sync`):** Adds `/sync` endpoint allowing external scripts, automation pipelines, or Gluetun hooks to trigger an immediate port check and synchronization.
- **UPnP Preference Guardrail (`QBIT_DISABLE_UPNP`):** When enabled, explicitly sets `upnp: false` in qBitTorrent preferences to prevent local port forwarding collisions over VPN.