### PR TITLE
chore(renovate): configure minimumReleaseAge and group all Go updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     ":semanticCommits",
     "helpers:pinGitHubActionDigests"
   ],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,13 @@
       "matchPackageNames": [
         "go",
         "golang",
-        "docker.io/library/golang"
+        "docker.io/library/golang",
+        "actions/go-versions",
+        "golang/go"
+      ],
+      "matchDatasources": [
+        "golang-version",
+        "docker"
       ],
       "groupName": "Go"
     },


### PR DESCRIPTION
### Summary

- Configures Renovate's `minimumReleaseAge` to `3 days`.
- Groups all Go version updates into a single PR across `go.mod`, `Dockerfile`, and GitHub Actions workflows (`actions/setup-go` / `actions/go-versions`).

### Rationale

- Prevents Renovate from opening PRs before downstream multi-arch Docker images (e.g. `golang:<version>-alpine`) are published.
- Ensures all Go version bumps across the codebase arrive together atomically in a single pull request.