### PR TITLE
chore(renovate): group all Go updates across go.mod, Dockerfile, and workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,11 +16,15 @@
         "actions/go-versions",
         "golang/go"
       ],
-      "matchDatasources": [
-        "golang-version",
-        "docker"
+      "matchDepNames": [
+        "go",
+        "golang",
+        "docker.io/library/golang",
+        "actions/go-versions",
+        "golang/go"
       ],
-      "groupName": "Go"
+      "groupName": "Go",
+      "rangeStrategy": "bump"
     },
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
### Summary

- Updates Go grouping rule to match both `matchPackageNames` and `matchDepNames` without restricting datasource (allowing `actions/go-versions` from GitHub Actions to be grouped).
- Sets `rangeStrategy: bump` so Renovate bumps the `go` directive in `go.mod` alongside Dockerfile and workflow updates.